### PR TITLE
Fix Vercel runtime config

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -3,7 +3,7 @@ import { buildServer } from '../src/serverCommon.js';
 import { ensureAuthorized, AuthError } from '../src/lib/auth.js';
 
 export const config = {
-  runtime: 'nodejs20.x',
+  runtime: 'nodejs',
   supportsResponseStreaming: true
 };
 


### PR DESCRIPTION
## Summary
- set the API server function runtime to the stable `nodejs` target supported by Vercel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca628d00c0832180323b06dde4edb7