### PR TITLE
Fix SSE runtime configuration

### DIFF
--- a/api/sse.ts
+++ b/api/sse.ts
@@ -3,7 +3,7 @@ import { buildServer } from '../src/serverCommon.js';
 import { ensureAuthorized, AuthError } from '../src/lib/auth.js';
 
 export const config = {
-  runtime: 'nodejs20.x',
+  runtime: 'nodejs',
   supportsResponseStreaming: true
 };
 


### PR DESCRIPTION
## Summary
- set the SSE API route runtime to `nodejs` to match the required runtime configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca64596fe4832196e6de88df9dd648